### PR TITLE
fix: make all packages available through the same global variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/demos/node/main.js"
+        }
+    ]
+}

--- a/config/base.js
+++ b/config/base.js
@@ -1,0 +1,3 @@
+module.exports = {
+  globalVariableName: "SC"
+};

--- a/config/base.js
+++ b/config/base.js
@@ -1,3 +1,4 @@
+// Just a utilities module that can be used by the webpack configs
 module.exports = {
   globalVariableName: "SC"
 };

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -10,7 +10,7 @@ module.exports = {
     libraryTarget: "umd",
     umdNamedDefine: true,
     // fix for https://github.com/webpack/webpack/issues/6525
-    globalObject: `(self || this)`
+    globalObject: `(typeof self !== 'undefined' ? self : this)`
   },
   resolve: {
     // Look for modules in .js files first

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -1,7 +1,4 @@
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
-// the variable name from which the library should be accessed from
-// when using a global var (ES6)
-const globalLibraryName = "SC";
 
 module.exports = {
   // devtool is already set with -d (debug) and removed with -p (production) flags from webpack and webpack dev server
@@ -9,7 +6,6 @@ module.exports = {
 
   // Output the bundled JS as UMD (Universal Module definition)
   output: {
-    library: globalLibraryName,
     // export itself to UMD format
     libraryTarget: "umd",
     umdNamedDefine: true,

--- a/config/webpack.umd.js
+++ b/config/webpack.umd.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const rootPath = path.join(__dirname, "../");
+const libraryName = require("./base").globalVariableName;
 
 // fetches and creates the packages that do not have a custom build script within
 const tsConfigReferences = require("../tsconfig").references;
@@ -10,6 +11,7 @@ const createBuildEntries = require("./scripts/createBuildEntries")(standardBuild
 module.exports = {
   entry: createBuildEntries("index.ts"),
   output: {
+    library: [libraryName, "[name]"],
     filename: "[name]/dist/scarlett-[name].js",
     path: path.resolve("packages")
   }

--- a/demos/browser/main.html
+++ b/demos/browser/main.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>My Javascript Library Test</title>
-    <script src="../packages/math/dist/scarlett-math.js"></script>
-    <script src="../packages/core/dist/scarlett-core.js"></script>
-    <script src="../packages/commons/dist/scarlett-commons.js"></script>
+    <script src="../../packages/math/dist/scarlett-math.js"></script>
+    <script src="../../packages/core/dist/scarlett-core.js"></script>
+    <script src="../../packages/commons/dist/scarlett-commons.js"></script>
   </head>
 
   <body>

--- a/demos/main.html
+++ b/demos/main.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <title>My Javascript Library Test</title>
     <script src="../packages/math/dist/scarlett-math.js"></script>
+    <script src="../packages/core/dist/scarlett-core.js"></script>
     <script src="../packages/commons/dist/scarlett-commons.js"></script>
   </head>
 

--- a/demos/node/main.js
+++ b/demos/node/main.js
@@ -1,0 +1,5 @@
+const commons = require("../../packages/commons/");
+
+const person = new commons.Simple();
+
+console.log(person);

--- a/packages/commons/webpack.config.js
+++ b/packages/commons/webpack.config.js
@@ -2,11 +2,16 @@ const path = require("path");
 const webpackMerge = require("webpack-merge");
 const baseConfig = require("../../config/webpack.base");
 
+// the variable name from which the library should be accessed from
+// when using a global var (ES6)
+const libraryName = require("../../config/base").globalVariableName;
+
 module.exports = (env = {}) => {
   // use UMD configuration by default
   let custom = {
     entry: "./index.ts",
     output: {
+      library: [libraryName, "commons"],
       filename: "scarlett-commons.js",
       path: path.resolve(__dirname, "./dist")
     },


### PR DESCRIPTION
This fixes #52

Basically, the packages can now be included separately, and as needed, in the HTML through the `script` tag—just as what happens in a node environment. This avoids the need of having a separate build with everything in a single bundle. It would be a waste since we are targeting _UMD_, which already has browsers in mind.

All of this is done automagically, unless a specific package needs a custom build (already supported), and in which cases we should do the following:
```javascript
// The variable name from which the library should be accessed from
// when using a global var (ES6)
const libraryName = require("../../config/base").globalVariableName;

// Inside module.exports
// Set other options (e.g., entry: "./index.ts")
output: {
  // In this example, it's the commons package. This will make it accessible
  // through SC.commons in a browser environment.
  library: [libraryName, "commons"],
  // (other options)
}
```

That said, here's how to use the packages:

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>My Javascript Library Test</title>
    <script src="../packages/math/dist/scarlett-math.js"></script>
    <script src="../packages/core/dist/scarlett-core.js"></script>
    <script src="../packages/commons/dist/scarlett-commons.js"></script>
  </head>

  <body>
    <div id="app"></div>
    <script src="main.js"></script>
  </body>
</html>
```

And can be accessed normally through:
```javascript
SC.math.X
SC.core.Y
SC.commons.Z
```