### PR TITLE
feat/webgl

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = api => {
     // examples below
     //loose: true,
     //modules: false,
+    //debug: true
   };
 
   // maybe use the following for "production"

--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -4,6 +4,12 @@ module.exports = {
   // devtool is already set with -d (debug) and removed with -p (production) flags from webpack and webpack dev server
   // devtool: 'source-map',
 
+  mode: "development",
+
+  optimization: {
+    usedExports: true
+  },
+
   // Output the bundled JS as UMD (Universal Module definition)
   output: {
     // export itself to UMD format

--- a/demos/browser/main.html
+++ b/demos/browser/main.html
@@ -6,10 +6,11 @@
     <script src="../../packages/math/dist/scarlett-math.js"></script>
     <script src="../../packages/core/dist/scarlett-core.js"></script>
     <script src="../../packages/common/dist/scarlett-common.js"></script>
+    <script src="../../packages/webgl/dist/scarlett-webgl.js"></script>
   </head>
 
   <body>
-    <div id="app"></div>
+    <canvas id="glCanvas" width="640" height="480"></canvas>
     <script src="main.js"></script>
   </body>
 </html>

--- a/demos/browser/main.js
+++ b/demos/browser/main.js
@@ -1,0 +1,5 @@
+const canvas = document.querySelector("#glCanvas");
+
+const gg = new SC.webgl.WebGLContext(canvas);
+
+gg.setVirtualResolution(640, 480);

--- a/demos/node/main.js
+++ b/demos/node/main.js
@@ -10,9 +10,14 @@ const data = JSON.stringify(geometry);
 console.log("geometry data", data);
 
 // deserialization
-const restoredObj = common.SerializationHelper.restoreFromJson(data, core.Geometry);
+const restoredObj = common.SerializationHelper.restoreFromJson(
+  data,
+  core.Geometry
+);
 
 console.log("restored geometry", restoredObj);
 
 console.log("instance of Geometry", restoredObj instanceof core.Geometry);
 console.log("instance of GameObject", restoredObj instanceof core.GameObject);
+
+console.log("is browser: ", common.isBrowser());

--- a/demos/node/main.js
+++ b/demos/node/main.js
@@ -21,3 +21,5 @@ console.log("instance of Geometry", restoredObj instanceof core.Geometry);
 console.log("instance of GameObject", restoredObj instanceof core.GameObject);
 
 console.log("is browser: ", common.isBrowser());
+
+console.log("rng: ", common.generateUUID());

--- a/packages/common/__tests__/serializeHelper.test.ts
+++ b/packages/common/__tests__/serializeHelper.test.ts
@@ -1,4 +1,4 @@
-import SerializationHelper from "../src/serializationHelper";
+import { SerializationHelper } from "../src/serializationHelper";
 import { toJson, jsonObject, jsonMember } from "typedjson";
 
 @toJson

--- a/packages/common/__tests__/simple.test.ts
+++ b/packages/common/__tests__/simple.test.ts
@@ -1,6 +1,6 @@
 // or import {Simple} from "common"
 // though you can't go to the definition that way
-import Simple from "../src/simple";
+import { Simple } from "../src/simple";
 
 test("Something", () => {
   expect.assertions(1);

--- a/packages/common/__tests__/utils.test.ts
+++ b/packages/common/__tests__/utils.test.ts
@@ -1,0 +1,46 @@
+import { generateUUID, isBrowser, isObjectAssigned } from "../src/utils";
+
+// just a quick way of checking if it's unique or not, since Sets only allow unique values within
+function isArrayUnique(myArray: Array<any>) {
+  return myArray.length === new Set(myArray).size;
+}
+
+test("generation of UUIDs is unique", () => {
+  expect.assertions(1);
+  let uuids: Array<string> = [];
+
+  const maxRange = 200;
+
+  // let's make the number of uuids different everytime so the test has more credibility
+  for (let i = 0; i < Math.floor(Math.random() * maxRange); i++) {
+    uuids.push(generateUUID());
+  }
+
+  const result = isArrayUnique(uuids);
+
+  expect(result).toBe(true);
+});
+
+test("is not running on browser", () => {
+  expect.assertions(1);
+
+  const result = isBrowser();
+
+  expect(result).toBe(false);
+});
+
+test("is object assigned", () => {
+  expect.assertions(5);
+
+  const nullResult = isObjectAssigned(null);
+  const undefinedResult = isObjectAssigned(undefined);
+  const numberResult = isObjectAssigned(3);
+  const stringResult = isObjectAssigned("");
+  const customObjectResult = isObjectAssigned({});
+
+  expect(nullResult).toBe(false);
+  expect(undefinedResult).toBe(false);
+  expect(numberResult).toBe(true);
+  expect(stringResult).toBe(true);
+  expect(customObjectResult).toBe(true);
+});

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,4 +1,5 @@
-export { default as Simple } from "./src/simple";
-export { default as Person } from "./src/person";
-export { default as SerializationHelper } from "./src/serializationHelper";
-export * from "./src/utils";
+export { Simple } from "./src/simple";
+export { Person } from "./src/person";
+export { SerializationHelper } from "./src/serializationHelper";
+export { isBrowser, isObjectAssigned, generateUUID } from "./src/utils";
+export * from "./src/math";

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,3 +1,4 @@
 export { default as Simple } from "./src/simple";
 export { default as Person } from "./src/person";
 export { default as SerializationHelper } from "./src/serializationHelper";
+export * from "./src/utils";

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@scarlett-game-studio/scarlett-common",
+  "sideEffects": false,
   "version": "0.0.1",
   "main": "dist/scarlett-common.js",
   "typings": "dist/index.d.ts",

--- a/packages/common/src/math.ts
+++ b/packages/common/src/math.ts
@@ -1,0 +1,7 @@
+export function square(x: any) {
+  return x * x;
+}
+
+export function cube(x: any) {
+  return x * x * x;
+}

--- a/packages/common/src/person.ts
+++ b/packages/common/src/person.ts
@@ -1,4 +1,4 @@
-import Simple from "./simple";
+import { Simple } from "./simple";
 import { jsonObject, jsonMember, TypedJSON, toJson } from "typedjson";
 
 @toJson
@@ -44,4 +44,4 @@ class Person {
   }
 }
 
-export default Person;
+export { Person };

--- a/packages/common/src/serializationHelper.ts
+++ b/packages/common/src/serializationHelper.ts
@@ -7,7 +7,7 @@ interface ParameterlessConstructor<T> {
   new (): T;
 }
 
-export default class SerializationHelper {
+export class SerializationHelper {
   static restoreFromJson<T>(data: any, target: ParameterlessConstructor<T>): T | undefined {
     const result = TypedJSON.parse(data, target);
     return result;

--- a/packages/common/src/simple.ts
+++ b/packages/common/src/simple.ts
@@ -20,4 +20,4 @@ class Simple {
   }
 }
 
-export default Simple;
+export { Simple };

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,4 +1,4 @@
-export { isObjectAssigned };
+export { isObjectAssigned, isBrowser };
 
 /**
  * Returns true if there is something assigned to the given object
@@ -7,4 +7,13 @@ export { isObjectAssigned };
  */
 function isObjectAssigned(obj: any): boolean {
   return typeof obj !== "undefined" && obj !== null;
+}
+
+/**
+ * Returns true when run under browser environment
+ * and false otherwise (e.g., node)
+ */
+function isBrowser(): boolean {
+  // @ts-ignore - just to ignore the 'this'
+  return typeof window !== "undefined" && this === window;
 }

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,4 +1,4 @@
-export { isObjectAssigned, isBrowser };
+export { isObjectAssigned, isBrowser, generateUUID };
 
 /**
  * Returns true if there is something assigned to the given object
@@ -12,8 +12,23 @@ function isObjectAssigned(obj: any): boolean {
 /**
  * Returns true when run under browser environment
  * and false otherwise (e.g., node)
+ * @returns {boolean}
  */
 function isBrowser(): boolean {
   // @ts-ignore - just to ignore the 'this'
   return typeof window !== "undefined" && this === window;
+}
+
+/**
+ * Returns a random v4 UUID of the form xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx,
+ * where each x is replaced with a random hexadecimal digit from 0 to f,
+ * and y is replaced with a random hexadecimal digit from 8 to b.
+ * Adapted (aka copied) from https://gist.github.com/jed/982883
+ * @returns {string}
+ */
+function generateUUID(): string {
+  // @ts-ignore - needed to support the + sign: [1e7] + -1e3
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
+    (c ^ ((Math.random() * 16) & (15 >> (c / 4)))).toString(16)
+  );
 }

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,11 +1,9 @@
-export { isObjectAssigned, isBrowser, generateUUID };
-
 /**
  * Returns true if there is something assigned to the given object
  * @param obj
  * @returns {boolean}
  */
-function isObjectAssigned(obj: any): boolean {
+export function isObjectAssigned(obj: any): boolean {
   return typeof obj !== "undefined" && obj !== null;
 }
 
@@ -14,7 +12,7 @@ function isObjectAssigned(obj: any): boolean {
  * and false otherwise (e.g., node)
  * @returns {boolean}
  */
-function isBrowser(): boolean {
+export function isBrowser(): boolean {
   // @ts-ignore - just to ignore the 'this'
   return typeof window !== "undefined" && this === window;
 }
@@ -26,7 +24,7 @@ function isBrowser(): boolean {
  * Adapted (aka copied) from https://gist.github.com/jed/982883
  * @returns {string}
  */
-function generateUUID(): string {
+export function generateUUID(): string {
   // @ts-ignore - needed to support the + sign: [1e7] + -1e3
   return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
     (c ^ ((Math.random() * 16) & (15 >> (c / 4)))).toString(16)

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,0 +1,10 @@
+export { isObjectAssigned };
+
+/**
+ * Returns true if there is something assigned to the given object
+ * @param obj
+ * @returns {boolean}
+ */
+function isObjectAssigned(obj: any): boolean {
+  return typeof obj !== "undefined" && obj !== null;
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,4 +1,4 @@
 export * from "./src/coreExample";
-export { default as GameObject } from "./src/gameObject";
-export { default as Geometry } from "./src/geometry";
-export { default as GameManager } from "./src/gameManager";
+export * from "./src/gameObject";
+export * from "./src/geometry";
+export * from "./src/gameManager";

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,3 +1,4 @@
 export * from "./src/coreExample";
 export { default as GameObject } from "./src/gameObject";
 export { default as Geometry } from "./src/geometry";
+export { default as GameManager } from "./src/gameManager";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@scarlett-game-studio/scarlett-core",
+  "sideEffects": false,
   "version": "0.0.1",
   "main": "dist/scarlett-core.js",
   "typings": "dist/index.d.ts",

--- a/packages/core/src/gameManager.ts
+++ b/packages/core/src/gameManager.ts
@@ -1,7 +1,7 @@
 /**
  * Game Manager static class
  */
-export default class GameManager {
+export class GameManager {
   //#region Static Properties
 
   public static RenderContext: RenderingContext;

--- a/packages/core/src/gameManager.ts
+++ b/packages/core/src/gameManager.ts
@@ -1,0 +1,14 @@
+/**
+ * Game Manager static class
+ */
+export default class GameManager {
+  //#region Static Properties
+
+  public static RenderContext: RenderingContext;
+  public static ActiveScene: any;
+  public static ActiveProject: any;
+  public static ActiveGame: any;
+  public static ActiveProjectPath: string;
+
+  //#endregion
+}

--- a/packages/core/src/gameObject.ts
+++ b/packages/core/src/gameObject.ts
@@ -7,4 +7,4 @@ class GameObject {
   prop?: string;
 }
 
-export default GameObject;
+export { GameObject };

--- a/packages/core/src/geometry.ts
+++ b/packages/core/src/geometry.ts
@@ -1,5 +1,5 @@
 import { jsonMember, jsonObject } from "typedjson";
-import GameObject from "./gameObject";
+import { GameObject } from "./gameObject";
 
 @jsonObject
 class Geometry extends GameObject {
@@ -7,4 +7,4 @@ class Geometry extends GameObject {
   num?: number;
 }
 
-export default Geometry;
+export { Geometry };

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@scarlett-game-studio/scarlett-math",
+  "sideEffects": false,
   "version": "0.0.1",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/shaders/index.ts
+++ b/packages/shaders/index.ts
@@ -1,0 +1,3 @@
+//export * from "./src/coreExample";
+//export { default as GameObject } from "./src/gameObject";
+//export { default as Geometry } from "./src/geometry";

--- a/packages/shaders/index.ts
+++ b/packages/shaders/index.ts
@@ -1,3 +1,0 @@
-//export * from "./src/coreExample";
-//export { default as GameObject } from "./src/gameObject";
-//export { default as Geometry } from "./src/geometry";

--- a/packages/shaders/package.json
+++ b/packages/shaders/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@scarlett-game-studio/scarlett-shaders",
+  "sideEffects": false,
   "version": "0.0.1",
   "main": "dist/scarlett-shaders.js",
   "typings": "dist/index.d.ts",

--- a/packages/shaders/package.json
+++ b/packages/shaders/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@scarlett-game-studio/scarlett-shaders",
+  "version": "0.0.1",
+  "main": "dist/scarlett-shaders.js",
+  "typings": "dist/index.d.ts",
+  "author": "Apidcloud <luisapidcloud@hotmail.com>",
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "3.3.3333"
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "check-types:watch": "yarn check-types --watch",
+    "build:types": "tsc --emitDeclarationOnly"
+  }
+}

--- a/packages/shaders/tsconfig.json
+++ b/packages/shaders/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "baseUrl": "src"
+  },
+  "include": ["src/**/*", "index.ts"]
+}

--- a/packages/webgl/index.ts
+++ b/packages/webgl/index.ts
@@ -1,3 +1,1 @@
-//export * from "./src/coreExample";
-//export { default as GameObject } from "./src/gameObject";
-export { default as WebGLContext } from "./src/webGLContext";
+export { WebGLContext } from "./src/webGLContext";

--- a/packages/webgl/index.ts
+++ b/packages/webgl/index.ts
@@ -1,0 +1,3 @@
+//export * from "./src/coreExample";
+//export { default as GameObject } from "./src/gameObject";
+//export { default as Geometry } from "./src/geometry";

--- a/packages/webgl/index.ts
+++ b/packages/webgl/index.ts
@@ -1,3 +1,3 @@
 //export * from "./src/coreExample";
 //export { default as GameObject } from "./src/gameObject";
-//export { default as Geometry } from "./src/geometry";
+export { default as WebGLContext } from "./src/webGLContext";

--- a/packages/webgl/package.json
+++ b/packages/webgl/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@scarlett-game-studio/scarlett-webgl",
+  "sideEffects": false,
   "version": "0.0.1",
   "main": "dist/scarlett-webgl.js",
   "typings": "dist/index.d.ts",

--- a/packages/webgl/package.json
+++ b/packages/webgl/package.json
@@ -5,7 +5,9 @@
   "typings": "dist/index.d.ts",
   "author": "Apidcloud <luisapidcloud@hotmail.com>",
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "@scarlett-game-studio/scarlett-common": "^0.0.1"
+  },
   "devDependencies": {
     "typescript": "3.3.3333"
   },

--- a/packages/webgl/package.json
+++ b/packages/webgl/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@scarlett-game-studio/scarlett-webgl",
+  "version": "0.0.1",
+  "main": "dist/scarlett-webgl.js",
+  "typings": "dist/index.d.ts",
+  "author": "Apidcloud <luisapidcloud@hotmail.com>",
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "3.3.3333"
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "check-types:watch": "yarn check-types --watch",
+    "build:types": "tsc --emitDeclarationOnly"
+  }
+}

--- a/packages/webgl/src/webGLContext.ts
+++ b/packages/webgl/src/webGLContext.ts
@@ -1,0 +1,91 @@
+/**
+ * WebGLContext Class
+ */
+import { isObjectAssigned } from "@scarlett-game-studio/scarlett-common";
+
+export default class WebGLContext {
+  //#region Fields
+
+  private _canvas: HTMLCanvasElement | null;
+  private _gl: WebGLRenderingContext | null;
+
+  //#endregion
+
+  /** 
+  get Name() {
+    return CONSTANTS.WEBGL;
+  }
+  **/
+
+  get Context(): WebGLRenderingContext | null {
+    return this._gl;
+  }
+
+  //#region Constructors
+
+  constructor(renderContainer: HTMLCanvasElement) {
+    this._gl = this.createContextFromContainer(renderContainer);
+    this._canvas = this._gl !== null ? renderContainer : null;
+  }
+
+  //#endregion
+
+  //#region Methods
+
+  setVirtualResolution(width: number, height: number): void {
+    if (this._gl === null || this._canvas === null) {
+      return;
+    }
+
+    this._canvas.width = width;
+    this._canvas.height = height;
+
+    this._gl.viewport(0, 0, width, height);
+  }
+
+  createContextFromContainer(
+    canvas: HTMLCanvasElement,
+    options = { alpha: false, antialias: true }
+  ): WebGLRenderingContext | null {
+    // let's try to get the webgl context from the given container:
+    // alpha is set to false to avoid webgl picking up the canvas color
+    // and place it on the alpha channel
+    // see: http://webglfundamentals.org/webgl/lessons/webgl-and-alpha.html
+
+    const gl: RenderingContext | null =
+      (canvas.getContext("experimental-webgl", options) as WebGLRenderingContext) ||
+      (canvas.getContext("webgl", options) as WebGLRenderingContext) ||
+      (canvas.getContext("webkit-3d", options) as WebGLRenderingContext) ||
+      (canvas.getContext("moz-webgl", options) as WebGLRenderingContext);
+
+    if (!isObjectAssigned(gl)) {
+      console.warn("WebGL not supported, find a container that does (eg. Chrome, Firefox)");
+      return null;
+    }
+
+    return gl;
+  }
+
+  setupWebGL(): void {
+    if (this._gl === null) {
+      return;
+    }
+
+    //console.log(gl.getSupportedExtensions());
+    this._gl.getExtension("OES_standard_derivatives");
+
+    // disable this._gl functions:
+    this._gl.disable(this._gl.CULL_FACE);
+    this._gl.disable(this._gl.DEPTH_TEST);
+
+    this._gl.blendFuncSeparate(this._gl.SRC_ALPHA, this._gl.ONE_MINUS_SRC_ALPHA, this._gl.ONE, this._gl.ONE);
+
+    // enable this._gl functions:
+    this._gl.enable(this._gl.BLEND);
+    this._gl.blendFunc(this._gl.SRC_ALPHA, this._gl.ONE_MINUS_SRC_ALPHA);
+  }
+
+  unload(): void {}
+
+  //#endregion
+}

--- a/packages/webgl/src/webGLContext.ts
+++ b/packages/webgl/src/webGLContext.ts
@@ -3,7 +3,7 @@
  */
 import { isObjectAssigned } from "@scarlett-game-studio/scarlett-common";
 
-export default class WebGLContext {
+export class WebGLContext {
   //#region Fields
 
   private _canvas: HTMLCanvasElement | null;

--- a/packages/webgl/tsconfig.json
+++ b/packages/webgl/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "baseUrl": "src"
+  },
+  "include": ["src/**/*", "index.ts"]
+}

--- a/packages/webgl/tsconfig.json
+++ b/packages/webgl/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "baseUrl": "src"
   },
-  "include": ["src/**/*", "index.ts"]
+  "include": ["src/**/*", "index.ts"],
+  "references": [{ "path": "../common" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,12 @@
     },
     {
       "path": "packages/math"
+    },
+    {
+      "path": "packages/shaders"
+    },
+    {
+      "path": "packages/webgl"
     }
   ]
 }


### PR DESCRIPTION
This PR should add both `webgl` and `shaders` packages, including:

- [x] WebGLContext

- [ ] WebGLUtils - I think it should be a static class, given the way it's being used.

- [ ] ...

By extension I also ended up creating `core/gameManager`. But I'm not entirely sure if `shaders` package should depend on the entire `core` package just because of `GameManager`. Doesn't that create a **circular reference**? Maybe not directly, since we would only be importing `GameManager`, but still. `GameObject`s will use shaders inside... An alternative would be to create an extra package for it, named `core-state` or something.